### PR TITLE
Fix ping on IPV6

### DIFF
--- a/templates/firewall.bash.j2
+++ b/templates/firewall.bash.j2
@@ -108,7 +108,7 @@ if [ -x "$(which ip6tables 2>/dev/null)" ]; then
   {% endfor %}
 
   # Accept icmp ping requests.
-  ip6tables -A INPUT -p icmp -j ACCEPT
+  ip6tables -A INPUT -p icmpv6 -j ACCEPT
 
   # Allow NTP traffic for time synchronization.
   ip6tables -A OUTPUT -p udp --dport 123 -j ACCEPT


### PR DESCRIPTION
on debian machines with properly set up IPv6, apt is broken, if the apt-gods decide that it should use ipv6. the proper protocol name for ICMP on ipv6 is icmpv6.